### PR TITLE
Add plugin option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,22 @@ var url = require('spawn-loader?name=bundle.js!./file');
 var url = require('spawn-loader?inert!./manifest.json');
 // url === 'manifest.json'
 ```
+
+### webpack.config.js Options
+
+**file.js**
+```js
+import React from 'react';
+```
+
+**webpack.config.js**
+```js
+// ...
+{
+  loader: 'spawn-loader',
+  options: {
+    // add plugins to the child compiler
+    plugins: [new webpack.ExternalsPlugin('var', { react: 'React' })]
+  }
+}
+```

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports.pitch = function(request) {
 	var outputDir = options.path || '.';
 	var plugins = options.plugins || [];
 	if (options.inert) {
-		plugins.push(new InertEntryPlugin());
+		plugins = [new InertEntryPlugin()].concat(plugins);
 	}
 
 	// name of the entry and compiler (in logs)

--- a/index.js
+++ b/index.js
@@ -19,7 +19,10 @@ module.exports.pitch = function(request) {
 	var options = loaderUtils.getOptions(this) || {};
 	var filename = options.name || path.basename(this.resourcePath);
 	var outputDir = options.path || '.';
-	var plugins = options.inert ? [new InertEntryPlugin()] : [];
+	var plugins = options.plugins || [];
+	if (options.inert) {
+		plugins.push(new InertEntryPlugin());
+	}
 
 	// name of the entry and compiler (in logs)
 	var debugName = loaderUtils.interpolateName(this, '[name]', {});


### PR DESCRIPTION
## This Pull Request:
Adds a `plugins` option.

## Why is this PR needed?
Child compilers don't inherit plugins from the root compiler. Therefore, it is currently not possible to implement things like [externals](https://webpack.js.org/configuration/externals/) in the spawned files. Rather than adding support for all internal Webpack plugins one-by-one, why not allow a plugin option instead?

Example usage with defining an external React, which will be excluded from the bundle and instead contains a module simply exporting `window.react`:

_file.js_
```js
import React from 'react';
```

_webpack.config.js_
```js
{
  loader: 'spawn-loader',
  options: {
    plugins: [new webpack.ExternalsPlugin('var', { react: 'React' })]
  }
}
```