### PR TITLE
Use resource path when adding dependency.

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports.pitch = function(request) {
 	new SingleEntryPlugin(this.context, '!!' + request, debugName).apply(compiler);
 
 	// add a dependency on the entry point of the child compiler, so watch mode works
-	this.addDependency(request);
+	this.addDependency(this.resourcePath);
 
 	// like compiler.runAsChild(), but remaps paths if necessary
 	// https://github.com/webpack/webpack/blob/f6e366b4be1cfe2770251a890d93081824789209/lib/Compiler.js#L206


### PR DESCRIPTION
## This Pull Request:
- Passes the absolute path to `addDependency`, rather than the provided remaining `request`.

## Why is this PR needed?
The `request` variable is in the inline loader format, and contains the remaining loaders. For example, if you're using `babel-loader` on your script files, then `request = "/path/to/project/node_modules/babel-loader/lib/index.js!/path/to/project/scripts/main.js"`.

This breaks watch mode, as `addDependency` expects the absolute path to the dependency itself, not including any loaders. Therefore, this PR uses `this.resourcePath`.

## Things to Note
I _think_ this might be a Webpack 5 only issue (this loader was working fine in Webpack 4 for me).